### PR TITLE
rename sentinal apache dubbo package name

### DIFF
--- a/sentinel-adapter/sentinel-apache-dubbo-adapter/src/main/java/com/alibaba/csp/sentinel/adapter/apache/dubbo/DubboAppContextFilter.java
+++ b/sentinel-adapter/sentinel-apache-dubbo-adapter/src/main/java/com/alibaba/csp/sentinel/adapter/apache/dubbo/DubboAppContextFilter.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.alibaba.csp.sentinel.adapter.dubbo;
+package com.alibaba.csp.sentinel.adapter.apache.dubbo;
 
 import org.apache.dubbo.common.Constants;
 import org.apache.dubbo.common.extension.Activate;

--- a/sentinel-adapter/sentinel-apache-dubbo-adapter/src/main/java/com/alibaba/csp/sentinel/adapter/apache/dubbo/DubboUtils.java
+++ b/sentinel-adapter/sentinel-apache-dubbo-adapter/src/main/java/com/alibaba/csp/sentinel/adapter/apache/dubbo/DubboUtils.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.alibaba.csp.sentinel.adapter.dubbo;
+package com.alibaba.csp.sentinel.adapter.apache.dubbo;
 
 import org.apache.dubbo.rpc.Invocation;
 import org.apache.dubbo.rpc.Invoker;

--- a/sentinel-adapter/sentinel-apache-dubbo-adapter/src/main/java/com/alibaba/csp/sentinel/adapter/apache/dubbo/SentinelDubboConsumerFilter.java
+++ b/sentinel-adapter/sentinel-apache-dubbo-adapter/src/main/java/com/alibaba/csp/sentinel/adapter/apache/dubbo/SentinelDubboConsumerFilter.java
@@ -13,17 +13,16 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.alibaba.csp.sentinel.adapter.dubbo;
+package com.alibaba.csp.sentinel.adapter.apache.dubbo;
 
 import com.alibaba.csp.sentinel.Entry;
 import com.alibaba.csp.sentinel.EntryType;
 import com.alibaba.csp.sentinel.SphU;
 import com.alibaba.csp.sentinel.Tracer;
-import com.alibaba.csp.sentinel.adapter.dubbo.fallback.DubboFallbackRegistry;
-import com.alibaba.csp.sentinel.context.ContextUtil;
 import com.alibaba.csp.sentinel.log.RecordLog;
 import com.alibaba.csp.sentinel.slots.block.BlockException;
 
+import com.alibaba.csp.sentinel.adapter.apache.dubbo.fallback.DubboFallbackRegistry;
 import org.apache.dubbo.common.extension.Activate;
 import org.apache.dubbo.rpc.Filter;
 import org.apache.dubbo.rpc.Invocation;
@@ -32,39 +31,31 @@ import org.apache.dubbo.rpc.Result;
 import org.apache.dubbo.rpc.RpcException;
 
 /**
- * <p>Apache Dubbo service provider filter that enables integration with Sentinel. Auto activated by default.</p>
- * <p>Note: this only works for Apache Dubbo 2.7.x or above version.</p>
+ * <p>Dubbo service consumer filter for Sentinel. Auto activated by default.</p>
  *
- * If you want to disable the provider filter, you can configure:
+ * If you want to disable the consumer filter, you can configure:
  * <pre>
- * &lt;dubbo:provider filter="-sentinel.dubbo.provider.filter"/&gt;
+ * &lt;dubbo:consumer filter="-sentinel.dubbo.consumer.filter"/&gt;
  * </pre>
  *
  * @author Carpenter Lee
  * @author Eric Zhao
  */
-@Activate(group = "provider")
-public class SentinelDubboProviderFilter implements Filter {
+@Activate(group = "consumer")
+public class SentinelDubboConsumerFilter implements Filter {
 
-    public SentinelDubboProviderFilter() {
-        RecordLog.info("Sentinel Apache Dubbo provider filter initialized");
+    public SentinelDubboConsumerFilter() {
+        RecordLog.info("Sentinel Apache Dubbo consumer filter initialized");
     }
 
     @Override
     public Result invoke(Invoker<?> invoker, Invocation invocation) throws RpcException {
-        // Get origin caller.
-        String application = DubboUtils.getApplication(invocation, "");
-
         Entry interfaceEntry = null;
         Entry methodEntry = null;
         try {
             String resourceName = DubboUtils.getResourceName(invoker, invocation);
-            String interfaceName = invoker.getInterface().getName();
-            // Only need to create entrance context at provider side, as context will take effect
-            // at entrance of invocation chain only (for inbound traffic).
-            ContextUtil.enter(resourceName, application);
-            interfaceEntry = SphU.entry(interfaceName, EntryType.IN);
-            methodEntry = SphU.entry(resourceName, EntryType.IN, 1, invocation.getArguments());
+            interfaceEntry = SphU.entry(invoker.getInterface().getName(), EntryType.OUT);
+            methodEntry = SphU.entry(resourceName, EntryType.OUT);
 
             Result result = invoker.invoke(invocation);
             if (result.hasException()) {
@@ -75,19 +66,18 @@ public class SentinelDubboProviderFilter implements Filter {
             }
             return result;
         } catch (BlockException e) {
-            return DubboFallbackRegistry.getProviderFallback().handle(invoker, invocation, e);
+            return DubboFallbackRegistry.getConsumerFallback().handle(invoker, invocation, e);
         } catch (RpcException e) {
             Tracer.traceEntry(e, interfaceEntry);
             Tracer.traceEntry(e, methodEntry);
             throw e;
         } finally {
             if (methodEntry != null) {
-                methodEntry.exit(1, invocation.getArguments());
+                methodEntry.exit();
             }
             if (interfaceEntry != null) {
                 interfaceEntry.exit();
             }
-            ContextUtil.exit();
         }
     }
 }

--- a/sentinel-adapter/sentinel-apache-dubbo-adapter/src/main/java/com/alibaba/csp/sentinel/adapter/apache/dubbo/fallback/DefaultDubboFallback.java
+++ b/sentinel-adapter/sentinel-apache-dubbo-adapter/src/main/java/com/alibaba/csp/sentinel/adapter/apache/dubbo/fallback/DefaultDubboFallback.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.alibaba.csp.sentinel.adapter.dubbo.fallback;
+package com.alibaba.csp.sentinel.adapter.apache.dubbo.fallback;
 
 import com.alibaba.csp.sentinel.slots.block.BlockException;
 import com.alibaba.csp.sentinel.slots.block.SentinelRpcException;

--- a/sentinel-adapter/sentinel-apache-dubbo-adapter/src/main/java/com/alibaba/csp/sentinel/adapter/apache/dubbo/fallback/DubboFallback.java
+++ b/sentinel-adapter/sentinel-apache-dubbo-adapter/src/main/java/com/alibaba/csp/sentinel/adapter/apache/dubbo/fallback/DubboFallback.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.alibaba.csp.sentinel.adapter.dubbo.fallback;
+package com.alibaba.csp.sentinel.adapter.apache.dubbo.fallback;
 
 import com.alibaba.csp.sentinel.slots.block.BlockException;
 

--- a/sentinel-adapter/sentinel-apache-dubbo-adapter/src/main/java/com/alibaba/csp/sentinel/adapter/apache/dubbo/fallback/DubboFallbackRegistry.java
+++ b/sentinel-adapter/sentinel-apache-dubbo-adapter/src/main/java/com/alibaba/csp/sentinel/adapter/apache/dubbo/fallback/DubboFallbackRegistry.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.alibaba.csp.sentinel.adapter.dubbo.fallback;
+package com.alibaba.csp.sentinel.adapter.apache.dubbo.fallback;
 
 import com.alibaba.csp.sentinel.util.AssertUtil;
 

--- a/sentinel-adapter/sentinel-apache-dubbo-adapter/src/main/resources/META-INF/dubbo/org.apache.dubbo.rpc.Filter
+++ b/sentinel-adapter/sentinel-apache-dubbo-adapter/src/main/resources/META-INF/dubbo/org.apache.dubbo.rpc.Filter
@@ -1,3 +1,3 @@
-sentinel.dubbo.provider.filter=com.alibaba.csp.sentinel.adapter.dubbo.SentinelDubboProviderFilter
-sentinel.dubbo.consumer.filter=com.alibaba.csp.sentinel.adapter.dubbo.SentinelDubboConsumerFilter
-dubbo.application.context.name.filter=com.alibaba.csp.sentinel.adapter.dubbo.DubboAppContextFilter
+sentinel.dubbo.provider.filter=com.alibaba.csp.sentinel.adapter.apache.dubbo.SentinelDubboProviderFilter
+sentinel.dubbo.consumer.filter=com.alibaba.csp.sentinel.adapter.apache.dubbo.SentinelDubboConsumerFilter
+dubbo.application.context.name.filter=com.alibaba.csp.sentinel.adapter.apache.dubbo.DubboAppContextFilter

--- a/sentinel-adapter/sentinel-apache-dubbo-adapter/src/test/java/com/alibaba/csp/sentinel/adapter/apache/dubbo/fallback/DubboFallbackRegistryTest.java
+++ b/sentinel-adapter/sentinel-apache-dubbo-adapter/src/test/java/com/alibaba/csp/sentinel/adapter/apache/dubbo/fallback/DubboFallbackRegistryTest.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.alibaba.csp.sentinel.adapter.dubbo.fallback;
+package com.alibaba.csp.sentinel.adapter.apache.dubbo.fallback;
 
 import com.alibaba.csp.sentinel.slots.block.BlockException;
 import com.alibaba.csp.sentinel.slots.block.SentinelRpcException;

--- a/sentinel-adapter/sentinel-apache-dubbo-adapter/src/test/java/com/alibaba/csp/sentinel/adapter/dubbo/DubboAppContextFilterTest.java
+++ b/sentinel-adapter/sentinel-apache-dubbo-adapter/src/test/java/com/alibaba/csp/sentinel/adapter/dubbo/DubboAppContextFilterTest.java
@@ -17,6 +17,8 @@ package com.alibaba.csp.sentinel.adapter.dubbo;
 
 import com.alibaba.csp.sentinel.BaseTest;
 
+import com.alibaba.csp.sentinel.adapter.apache.dubbo.DubboAppContextFilter;
+import com.alibaba.csp.sentinel.adapter.apache.dubbo.DubboUtils;
 import org.apache.dubbo.common.URL;
 import org.apache.dubbo.rpc.Invocation;
 import org.apache.dubbo.rpc.Invoker;

--- a/sentinel-adapter/sentinel-apache-dubbo-adapter/src/test/java/com/alibaba/csp/sentinel/adapter/dubbo/DubboUtilsTest.java
+++ b/sentinel-adapter/sentinel-apache-dubbo-adapter/src/test/java/com/alibaba/csp/sentinel/adapter/dubbo/DubboUtilsTest.java
@@ -15,6 +15,7 @@
  */
 package com.alibaba.csp.sentinel.adapter.dubbo;
 
+import com.alibaba.csp.sentinel.adapter.apache.dubbo.DubboUtils;
 import org.apache.dubbo.rpc.Invocation;
 import org.apache.dubbo.rpc.Invoker;
 import org.junit.Test;

--- a/sentinel-adapter/sentinel-apache-dubbo-adapter/src/test/java/com/alibaba/csp/sentinel/adapter/dubbo/SentinelDubboConsumerFilterTest.java
+++ b/sentinel-adapter/sentinel-apache-dubbo-adapter/src/test/java/com/alibaba/csp/sentinel/adapter/dubbo/SentinelDubboConsumerFilterTest.java
@@ -19,6 +19,8 @@ import com.alibaba.csp.sentinel.BaseTest;
 import com.alibaba.csp.sentinel.Constants;
 import com.alibaba.csp.sentinel.Entry;
 import com.alibaba.csp.sentinel.EntryType;
+import com.alibaba.csp.sentinel.adapter.apache.dubbo.DubboUtils;
+import com.alibaba.csp.sentinel.adapter.apache.dubbo.SentinelDubboConsumerFilter;
 import com.alibaba.csp.sentinel.adapter.dubbo.provider.DemoService;
 import com.alibaba.csp.sentinel.context.Context;
 import com.alibaba.csp.sentinel.context.ContextUtil;

--- a/sentinel-adapter/sentinel-apache-dubbo-adapter/src/test/java/com/alibaba/csp/sentinel/adapter/dubbo/SentinelDubboProviderFilterTest.java
+++ b/sentinel-adapter/sentinel-apache-dubbo-adapter/src/test/java/com/alibaba/csp/sentinel/adapter/dubbo/SentinelDubboProviderFilterTest.java
@@ -18,6 +18,8 @@ package com.alibaba.csp.sentinel.adapter.dubbo;
 import com.alibaba.csp.sentinel.BaseTest;
 import com.alibaba.csp.sentinel.Entry;
 import com.alibaba.csp.sentinel.EntryType;
+import com.alibaba.csp.sentinel.adapter.apache.dubbo.DubboUtils;
+import com.alibaba.csp.sentinel.adapter.apache.dubbo.SentinelDubboProviderFilter;
 import com.alibaba.csp.sentinel.adapter.dubbo.provider.DemoService;
 import com.alibaba.csp.sentinel.context.Context;
 import com.alibaba.csp.sentinel.context.ContextUtil;


### PR DESCRIPTION
### 说明
sentinel-apache-dubbo-adapter  和 sentinel-dubbo-adapter 两个工程 分别针对 dubbo 2.7.x 和 dubbo 2.7.0 以前的版本。如果同时引入这两个 adapter jar 包时，会出现 package name 相同的情况，于是需要重新命名 sentinel-apache-dubbo-adapter jar 包。